### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,6 +18,8 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mseminatore/as09/security/code-scanning/1](https://github.com/mseminatore/as09/security/code-scanning/1)

In general, to fix this issue you add an explicit `permissions` section that restricts the `GITHUB_TOKEN` to the minimal rights needed. For a simple CI workflow that only checks out code and runs CMake/ctest, read access to repository contents is sufficient; no write or additional scopes are required.

The best fix here is to define a job-level `permissions` block under `jobs.build`, parallel to `runs-on`. This keeps the restriction local to this job and avoids affecting any other jobs that might be added later. Specifically, in `.github/workflows/cmake.yml`, under `jobs: build:`, insert:
```yaml
permissions:
  contents: read
```
on its own indentation level between `runs-on: ubuntu-latest` and `steps:`. No additional imports or methods are needed because this is purely declarative YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
